### PR TITLE
Require Observation period when era pad is specified for eraFy function

### DIFF
--- a/R/DeleteCohortRecords.R
+++ b/R/DeleteCohortRecords.R
@@ -27,6 +27,8 @@
 #' @template CohortTable
 #'
 #' @template CohortIds
+#' 
+#' @template CohortDatabaseSchema
 #'
 #' @template TempEmulationSchema
 #'

--- a/R/EraFyCohort.R
+++ b/R/EraFyCohort.R
@@ -28,6 +28,8 @@
 #'
 #' @template CohortTable
 #'
+#' @template CohortDatabaseSchema
+#'
 #' @template OldToNewCohortId
 #'
 #' @template PurgeConflicts
@@ -35,6 +37,11 @@
 #' @template TempEmulationSchema
 #'
 #' @param eraconstructorpad   Optional value to pad cohort era construction logic. Default = 0. i.e. no padding.
+#' 
+#' @param cdmDatabaseSchema   Schema name where your patient-level data in OMOP CDM format resides.
+#'                            Note that for SQL Server, this should include both the database and
+#'                            schema name, for example 'cdm_data.dbo'. cdmDataschema is required
+#'                            when eraConstructorPad is > 0. eraConstructorPad is optional.
 #'
 #' @return
 #' NULL
@@ -46,6 +53,7 @@ eraFyCohorts <- function(connectionDetails = NULL,
                          cohortTable = "cohort",
                          oldToNewCohortId,
                          eraconstructorpad = 0,
+                         cdmDatabaseSchema = NULL,
                          tempEmulationSchema = getOption("sqlRenderTempEmulationSchema"),
                          purgeConflicts = FALSE) {
   errorMessages <- checkmate::makeAssertCollection()
@@ -79,6 +87,13 @@ eraFyCohorts <- function(connectionDetails = NULL,
     add = errorMessages
   )
   checkmate::assertCharacter(
+    x = cdmDatabaseSchema,
+    min.chars = 1,
+    len = 1,
+    null.ok = TRUE,
+    add = errorMessages
+  )
+  checkmate::assertCharacter(
     x = cohortTable,
     min.chars = 1,
     len = 1,
@@ -92,6 +107,17 @@ eraFyCohorts <- function(connectionDetails = NULL,
     add = errorMessages
   )
   checkmate::reportAssertions(collection = errorMessages)
+  
+  if (is.null(cdmDatabaseSchema)) {
+    if (eraconstructorpad > 0) {
+      stop(
+        "cdmDatabaseSchema is NULL but eraconstructorpad > 0. This may result in cohorts that
+            that are outside a persons observation period - ie. the resultant cohort is not valid.
+            To avoid this - please always provide cdmDatabaseSchema with eraConstructorPad.
+            The function will then ensure that cohort days are always in observation period."
+      )
+    }
+  }
 
   if (is.null(connection)) {
     connection <- DatabaseConnector::connect(connectionDetails)
@@ -192,12 +218,31 @@ eraFyCohorts <- function(connectionDetails = NULL,
                 	                      c.subject_id = e.subject_id AND
                 	                      e.cohort_end_date >= c.cohort_start_date
                 	GROUP BY c.cohort_definition_id, c.subject_id, c.cohort_start_date
-                )
+                ), 
+                cohort_era as
+                (
                 select cohort_definition_id, subject_id, min(cohort_start_date) as cohort_start_date, cohort_end_date
-                into @temp_table_2
                 from cteEnds
                 group by cohort_definition_id, subject_id, cohort_end_date
-                ;
+                )
+                {@cdm_database_schema != ''} ? 
+                {SELECT ce.cohort_definition_id,
+                        ce.subject_id,
+                        CASE WHEN op.observation_period_start_date < ce.cohort_start_date THEN ce.cohort_start_date
+                            ELSE op.observation_period_start_date END cohort_start_date,
+                        CASE WHEN op.observation_period_end_date > ce.cohort_end_date then ce.cohort_end_date
+                            ELSE op.observation_period_end_date END cohort_end_date
+                  into @temp_table_2
+                  FROM cohort_era ce
+                  INNER JOIN @cdm_database_schema.observation_period op
+                  ON ce.subject_id = op.person_id
+                  WHERE op.observation_period_start_date <= ce.cohort_start_date
+                        AND op.observation_period_end_date >= ce.cohort_start_date 
+                        -- only returns overlapping periods;} : 
+                {SELECT * 
+                 INTO @temp_table_2
+                 FROM cohort_era;
+                }
   "
 
   DatabaseConnector::renderTranslateExecuteSql(
@@ -208,6 +253,7 @@ eraFyCohorts <- function(connectionDetails = NULL,
     reportOverallTime = FALSE,
     tempEmulationSchema = tempEmulationSchema,
     eraconstructorpad = eraconstructorpad,
+    cdm_database_schema = cdmDatabaseSchema,
     temp_table_1 = tempTable1,
     temp_table_2 = tempTable2
   )

--- a/R/EraFyCohort.R
+++ b/R/EraFyCohort.R
@@ -229,21 +229,21 @@ eraFyCohorts <- function(connectionDetails = NULL,
                 {SELECT ce.cohort_definition_id,
                         ce.subject_id,
                         CASE WHEN op.observation_period_start_date < ce.cohort_start_date THEN ce.cohort_start_date
-                            ELSE op.observation_period_start_date END cohort_start_date,
+                            ELSE op.observation_period_start_date END AS cohort_start_date,
                         CASE WHEN op.observation_period_end_date > ce.cohort_end_date then ce.cohort_end_date
-                            ELSE op.observation_period_end_date END cohort_end_date
+                            ELSE op.observation_period_end_date END AS cohort_end_date
                   into @temp_table_2
                   FROM cohort_era ce
                   INNER JOIN @cdm_database_schema.observation_period op
                   ON ce.subject_id = op.person_id
                   WHERE op.observation_period_start_date <= ce.cohort_start_date
                         AND op.observation_period_end_date >= ce.cohort_start_date 
-                        -- only returns overlapping periods;} : 
+                        -- only returns overlapping periods} : 
                 {SELECT * 
                  INTO @temp_table_2
-                 FROM cohort_era;
+                 FROM cohort_era
                 }
-  "
+ ; "
 
   DatabaseConnector::renderTranslateExecuteSql(
     connection = connection,

--- a/R/GetCohortIdsInCohortTable.R
+++ b/R/GetCohortIdsInCohortTable.R
@@ -22,6 +22,8 @@
 #' @template Connection
 #'
 #' @template CohortTable
+#' 
+#' @template CohortDatabaseSchema
 #'
 #' @template TempEmulationSchema
 #'

--- a/R/IntersectCohorts.R
+++ b/R/IntersectCohorts.R
@@ -27,6 +27,8 @@
 #' @template Connection
 #'
 #' @template CohortTable
+#' 
+#' @template CohortDatabaseSchema
 #'
 #' @template CohortIds
 #'

--- a/R/MinusCohorts.R
+++ b/R/MinusCohorts.R
@@ -25,6 +25,8 @@
 #' @template Connection
 #'
 #' @template CohortTable
+#' 
+#' @template CohortDatabaseSchema
 #'
 #' @param firstCohortId The cohort id of the cohort from which to substract.
 #'

--- a/man-roxygen/CdmDatabaseSchema.R
+++ b/man-roxygen/CdmDatabaseSchema.R
@@ -1,3 +1,0 @@
-#' @param cdmDatabaseSchema   Schema name where your patient-level data in OMOP CDM format resides.
-#'                            Note that for SQL Server, this should include both the database and
-#'                            schema name, for example 'cdm_data.dbo'.

--- a/man-roxygen/CohortTable.R
+++ b/man-roxygen/CohortTable.R
@@ -1,4 +1,1 @@
-#' @param cohortDatabaseSchema   Schema name where your cohort table resides. Note that for SQL Server,
-#'                               this should include both the database and schema name, for example
-#'                               'scratch.dbo'.
 #' @param cohortTable            The name of the cohort table.

--- a/man/deleteCohortRecords.Rd
+++ b/man/deleteCohortRecords.Rd
@@ -25,6 +25,10 @@ DatabaseConnector package. Can be left NULL if \code{connectionDetails}
 is provided, in which case a new connection will be opened at the start
 of the function, and closed when the function finishes.}
 
+\item{cohortDatabaseSchema}{Schema name where your cohort tables reside. Note that for SQL Server,
+this should include both the database and schema name, for example
+'scratch.dbo'.}
+
 \item{cohortTable}{The name of the cohort table.}
 
 \item{tempEmulationSchema}{Some database platforms like Oracle and Impala do not truly support

--- a/man/deleteCohortRecords.Rd
+++ b/man/deleteCohortRecords.Rd
@@ -25,10 +25,6 @@ DatabaseConnector package. Can be left NULL if \code{connectionDetails}
 is provided, in which case a new connection will be opened at the start
 of the function, and closed when the function finishes.}
 
-\item{cohortDatabaseSchema}{Schema name where your cohort table resides. Note that for SQL Server,
-this should include both the database and schema name, for example
-'scratch.dbo'.}
-
 \item{cohortTable}{The name of the cohort table.}
 
 \item{tempEmulationSchema}{Some database platforms like Oracle and Impala do not truly support

--- a/man/eraFyCohorts.Rd
+++ b/man/eraFyCohorts.Rd
@@ -11,6 +11,7 @@ eraFyCohorts(
   cohortTable = "cohort",
   oldToNewCohortId,
   eraconstructorpad = 0,
+  cdmDatabaseSchema = NULL,
   tempEmulationSchema = getOption("sqlRenderTempEmulationSchema"),
   purgeConflicts = FALSE
 )
@@ -27,7 +28,7 @@ DatabaseConnector package. Can be left NULL if \code{connectionDetails}
 is provided, in which case a new connection will be opened at the start
 of the function, and closed when the function finishes.}
 
-\item{cohortDatabaseSchema}{Schema name where your cohort table resides. Note that for SQL Server,
+\item{cohortDatabaseSchema}{Schema name where your cohort tables reside. Note that for SQL Server,
 this should include both the database and schema name, for example
 'scratch.dbo'.}
 
@@ -40,6 +41,11 @@ If the oldCohortId = newCohortId then the data corresponding to oldCohortId
 will be replaced by the data from the newCohortId.}
 
 \item{eraconstructorpad}{Optional value to pad cohort era construction logic. Default = 0. i.e. no padding.}
+
+\item{cdmDatabaseSchema}{Schema name where your patient-level data in OMOP CDM format resides.
+Note that for SQL Server, this should include both the database and
+schema name, for example 'cdm_data.dbo'. cdmDataschema is required
+when eraConstructorPad is > 0. eraConstructorPad is optional.}
 
 \item{tempEmulationSchema}{Some database platforms like Oracle and Impala do not truly support
 temp tables. To emulate temp tables, provide a schema with write

--- a/man/getCohortIdsInCohortTable.Rd
+++ b/man/getCohortIdsInCohortTable.Rd
@@ -18,7 +18,7 @@ DatabaseConnector package. Can be left NULL if \code{connectionDetails}
 is provided, in which case a new connection will be opened at the start
 of the function, and closed when the function finishes.}
 
-\item{cohortDatabaseSchema}{Schema name where your cohort table resides. Note that for SQL Server,
+\item{cohortDatabaseSchema}{Schema name where your cohort tables reside. Note that for SQL Server,
 this should include both the database and schema name, for example
 'scratch.dbo'.}
 

--- a/man/intersectCohorts.Rd
+++ b/man/intersectCohorts.Rd
@@ -27,7 +27,7 @@ DatabaseConnector package. Can be left NULL if \code{connectionDetails}
 is provided, in which case a new connection will be opened at the start
 of the function, and closed when the function finishes.}
 
-\item{cohortDatabaseSchema}{Schema name where your cohort table resides. Note that for SQL Server,
+\item{cohortDatabaseSchema}{Schema name where your cohort tables reside. Note that for SQL Server,
 this should include both the database and schema name, for example
 'scratch.dbo'.}
 

--- a/man/minusCohorts.Rd
+++ b/man/minusCohorts.Rd
@@ -28,7 +28,7 @@ DatabaseConnector package. Can be left NULL if \code{connectionDetails}
 is provided, in which case a new connection will be opened at the start
 of the function, and closed when the function finishes.}
 
-\item{cohortDatabaseSchema}{Schema name where your cohort table resides. Note that for SQL Server,
+\item{cohortDatabaseSchema}{Schema name where your cohort tables reside. Note that for SQL Server,
 this should include both the database and schema name, for example
 'scratch.dbo'.}
 


### PR DESCRIPTION
When eraPad is specified, it extends the cohort period (end date) based on the era - when eraFying two or more cohorts for the same person (its possible use oldToNewCohortId object). If the cohort period end up outside the persons observation_period that is an invalid cohort.

This PR forces the use of observation_period table and limiting the eraFy'd cohort period to the observation_period.